### PR TITLE
Make PHImageManagerImageDataResult publicly immutable.

### DIFF
--- a/PINFuture/Classes/PHImageManager+PINFuture.h
+++ b/PINFuture/Classes/PHImageManager+PINFuture.h
@@ -17,10 +17,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface PHImageManagerImageDataResult : NSObject
 
-@property (nonatomic) NSData *imageData;
-@property (nonatomic) NSString *dataUTI;
-@property (nonatomic) UIImageOrientation orientation;
-@property (nonatomic) NSDictionary *info;
+@property (nonatomic, readonly) NSData *imageData;
+@property (nonatomic, copy, readonly) NSString *dataUTI;
+@property (nonatomic, readonly) UIImageOrientation orientation;
+@property (nonatomic, readonly) NSDictionary *info;
 
 @end
 

--- a/PINFuture/Classes/PHImageManager+PINFuture.m
+++ b/PINFuture/Classes/PHImageManager+PINFuture.m
@@ -10,6 +10,20 @@
 
 @implementation PHImageManagerImageDataResult
 
+- (instancetype)initWithImageData:(NSData *)imageData
+                          dataUTI:(NSString *)dataUTI
+                      orientation:(UIImageOrientation)orientation
+                             info:(NSDictionary *)info
+{
+    if (self = [super init]) {
+        _imageData = imageData;
+        _dataUTI = dataUTI;
+        _orientation = orientation;
+        _info = info;
+    }
+    return self;
+}
+
 @end
 
 @implementation PHImageManager (PINFuture)
@@ -19,12 +33,10 @@
     return [PINFuture<PHImageManagerImageDataResult *> futureWithBlock:^(void (^ _Nonnull resolve)(PHImageManagerImageDataResult * _Nonnull), void (^ _Nonnull reject)(NSError * _Nonnull)) {
         [self requestImageDataForAsset:asset options:options resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
             if (imageData) {
-                PHImageManagerImageDataResult *result = [[PHImageManagerImageDataResult alloc] init];
-                result.imageData = imageData;
-                result.dataUTI = dataUTI;
-                result.orientation = orientation;
-                result.info = info;
-
+                PHImageManagerImageDataResult *result = [[PHImageManagerImageDataResult alloc] initWithImageData:imageData
+                                                                                                         dataUTI:dataUTI
+                                                                                                     orientation:orientation
+                                                                                                            info:info];
                 resolve(result);
             } else {
                 NSString *failureReason = NSLocalizedString(@"Invalid Image Data", @"Failure reason for Invalid Image Data");


### PR DESCRIPTION
This makes the properties of `PHImageManagerImageDataResult` publicly immutable and only specifiable at initialization time.