### PR TITLE
Result WIP

### DIFF
--- a/Example/Tests/PINResultTests.m
+++ b/Example/Tests/PINResultTests.m
@@ -1,0 +1,31 @@
+//
+// Created by Brandon Kase on 12/19/16.
+// Copyright (c) 2016 Pinterest. All rights reserved.
+//
+
+#import "PINResult.h"
+#import "TestUtil.h"
+
+SpecBegin(PINResultSpec)
+
+describe(@"Result can be created and matched", ^{
+    NSNumber * res = [[PINResult2 match:[PINResult succeedWith:@"Yes"]
+        success:^NSNumber *(NSString *value){
+            return @1;
+        }]
+     failure:^NSNumber *(NSError *error){
+         return @2;
+     }];
+    expect(res).to.equal(@1);
+
+    NSNumber * res2 = [[PINResult2 match:[PINResult failWith:[NSError errorWithDomain:@"failed" code:1 userInfo: nil]]
+                                success:^NSNumber *(NSString *value){
+                                    return @1;
+                                }]
+                      failure:^NSNumber *(NSError *error){
+                          return @2;
+                      }];
+    expect(res2).to.equal(@2);
+});
+
+SpecEnd

--- a/PINFuture/Classes/PINResult.h
+++ b/PINFuture/Classes/PINResult.h
@@ -1,0 +1,26 @@
+//
+//  PINResult.h
+//  Pods
+//
+//  Created by Brandon Kase on 12/19/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class PINResultSuccess<ObjectType>;
+@class PINResultFailure<ObjectType>;
+
+/**
+ * A Result is value that has either succeeded or failed.
+ */
+@interface PINResult<ObjectType> : NSObject
+
++ (PINResultSuccess<ObjectType> *)succeedWith:(ObjectType)value;
++ (PINResultFailure<ObjectType> *)failWith:(NSError *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PINFuture/Classes/PINResult.m
+++ b/PINFuture/Classes/PINResult.m
@@ -1,0 +1,24 @@
+//
+//  PINResult.m
+//  Pods
+//
+//  Created by Brandon Kase on 12/19/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "PINResult.h"
+#import "PINResultSuccess.h"
+#import "PINResultFailure.h"
+
+@implementation PINResult
++ (PINResultSuccess <id> *)succeedWith:(id)value {
+    return [[PINResultSuccess alloc] initWithValue:value];
+}
+
++ (PINResultFailure <id> *)failWith:(NSError *)error {
+    return [[PINResultFailure alloc] initWithError:error];
+}
+
+
+@end

--- a/PINFuture/Classes/PINResult2.h
+++ b/PINFuture/Classes/PINResult2.h
@@ -1,0 +1,19 @@
+//
+//  PinResult2.h
+//  Pods
+//
+//  Created by Brandon Kase on 12/19/16.
+//
+//
+
+#import "PINResult.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PINResult2<ValueType, ToType> : NSObject
+
++ (ToType)match:(PINResult<ValueType> *)result success:(ToType (^)(ValueType value))success failure:(ToType (^)(NSError * error))failure;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PINFuture/Classes/PINResult2.m
+++ b/PINFuture/Classes/PINResult2.m
@@ -1,0 +1,35 @@
+//
+//  PINResult2.m
+//  Pods
+//
+//  Created by Brandon Kase on 12/19/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "PINResult2.h"
+#import "PINResultSuccess.h"
+#import "PINResultFailure.h"
+
+@interface PINResultSuccess<ValueType> (private)
+@property (nonatomic, strong) id value;
+@end
+
+@interface PINResultFailure<ValueType> (private)
+@property (nonatomic, strong) NSError *error;
+@end
+
+@implementation PINResult2
++ (id)match:(PINResult <id> *)result success:(id (^)(id))success failure:(id (^)(NSError *))failure {
+    if ([self isKindOfClass:[PINResultSuccess class]]) {
+        return success(((PINResultSuccess *)self).value);
+    } else if ([self isKindOfClass:[PINResultFailure class]]) {
+        return failure(((PINResultFailure *)self).error);
+    } else {
+        NSAssert(NO, @"Match error");
+        return nil;
+    }
+}
+
+
+@end

--- a/PINFuture/Classes/PINResultFailure.h
+++ b/PINFuture/Classes/PINResultFailure.h
@@ -1,0 +1,26 @@
+//
+//  PINResultFailure.h
+//  Pods
+//
+//  Created by Brandon Kase on 12/19/16.
+//
+//
+
+#import "PINResult.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * A Result is value that has either succeeded or failed.
+ */
+@interface PINResultFailure<ObjectType> : PINResult<ObjectType>
+
+/**
+ * Return a failed result.
+ */
+- (PINResultFailure<ObjectType> *)initWithError:(NSError *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PINFuture/Classes/PINResultFailure.m
+++ b/PINFuture/Classes/PINResultFailure.m
@@ -1,0 +1,22 @@
+//
+// Created by Brandon Kase on 12/19/16.
+// Copyright (c) 2016 Pinterest. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "PINResultFailure.h"
+
+@interface PINResultFailure ()
+@property (nonatomic, strong) NSError *error;
+@end
+
+@implementation PINResultFailure
+
+- (PINResultFailure <id> *)initWithError:(NSError *)error {
+    if (self == [super init]) {
+        self.error = error;
+    }
+    return self;
+}
+
+@end

--- a/PINFuture/Classes/PINResultSuccess.h
+++ b/PINFuture/Classes/PINResultSuccess.h
@@ -1,0 +1,25 @@
+//
+//  PINResultSuccess.h
+//  Pods
+//
+//  Created by Brandon Kase on 12/19/16.
+//
+//
+
+#import "PINResult.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * A Result is value that has either succeeded or failed.
+ */
+@interface PINResultSuccess<ObjectType> : PINResult<ObjectType>
+
+/**
+ * Return a successful result.
+ */
+- (PINResultSuccess<ObjectType> *)initWithValue:(ObjectType)value;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PINFuture/Classes/PINResultSuccess.m
+++ b/PINFuture/Classes/PINResultSuccess.m
@@ -1,0 +1,22 @@
+//
+// Created by Brandon Kase on 12/19/16.
+// Copyright (c) 2016 Pinterest. All rights reserved.
+//
+
+#import "PINResultSuccess.h"
+
+@interface PINResultSuccess ()
+@property (nonatomic, strong) id value;
+@end
+
+
+@implementation PINResultSuccess
+
+- (PINResultSuccess <id> *)initWithValue:(id)value {
+    if (self == [super init]) {
+        self.value = value;
+    }
+    return self;
+}
+
+@end


### PR DESCRIPTION
Cocoapods is not fully set up, so I can't actually run the tests yet. I wanted to get feedback on my Objective-C to make sure I was doing stuff right (the test file may be broken, the others should compile).

The `PINResult` is morally a disjoint union implemented via subclassing and passing blocks via a match method.

(this "either" thing is what I want to wrap in a macro soon)

TODO: Change map to use it