### PR TITLE
Add sdk_frameworks to Bazel build file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7,5 +7,9 @@ objc_library(
     "PINFuture/Classes/Categories",
   ],
   copts = ["-w"],
+  sdk_frameworks = [
+  	"AssetsLibrary",
+  	"Photos"
+  ],
   visibility = ["//visibility:public"]
 )


### PR DESCRIPTION
We should also define SDK frameworks that PINFuture relies on. This came up for me when I was trying to run tests on a library that transitively depends on PINFuture.