### PR TITLE
use [data copy] to be extra safe

### DIFF
--- a/PINFuture/Classes/Categories/NSURLSession+PINFuture.m
+++ b/PINFuture/Classes/Categories/NSURLSession+PINFuture.m
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
     PINFuture<PINNSURLSessionDataTaskResult *> *future;
     future = [PINFuture<PINNSURLSessionDataTaskResult *> withBlock:^(void (^ _Nonnull resolve)(id _Nonnull), void (^ _Nonnull reject)(NSError * _Nonnull)) {
         task = [self dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error)  {
-            PINNSURLSessionDataTaskResult *result = [PINNSURLSessionDataTaskResult resultWithData:[data copy] response:response error:error];
+            PINNSURLSessionDataTaskResult *result = [PINNSURLSessionDataTaskResult resultWithData:data response:response error:error];
             resolve(result);
         }];
         task.priority = priority;

--- a/PINFuture/Classes/Categories/NSURLSession+PINFuture.m
+++ b/PINFuture/Classes/Categories/NSURLSession+PINFuture.m
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
     PINFuture<PINNSURLSessionDataTaskResult *> *future;
     future = [PINFuture<PINNSURLSessionDataTaskResult *> withBlock:^(void (^ _Nonnull resolve)(id _Nonnull), void (^ _Nonnull reject)(NSError * _Nonnull)) {
         task = [self dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error)  {
-            PINNSURLSessionDataTaskResult *result = [PINNSURLSessionDataTaskResult resultWithData:data response:response error:error];
+            PINNSURLSessionDataTaskResult *result = [PINNSURLSessionDataTaskResult resultWithData:[data copy] response:response error:error];
             resolve(result);
         }];
         task.priority = priority;

--- a/PINFuture/Classes/Categories/PINNSURLSessionDataTaskResult.h
+++ b/PINFuture/Classes/Categories/PINNSURLSessionDataTaskResult.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PINNSURLSessionDataTaskResult : NSObject
 
 @property (nonatomic, readonly) NSData * _Nullable data;
-@property (nonatomic, readonly) NSURLResponse * _Nullable response;
+@property (nonatomic, copy, readonly) NSURLResponse * _Nullable response;
 @property (nonatomic, readonly) NSError * _Nullable error;
 
 + (instancetype)resultWithData:(NSData * _Nullable)data

--- a/PINFuture/Classes/Categories/PINNSURLSessionDataTaskResult.m
+++ b/PINFuture/Classes/Categories/PINNSURLSessionDataTaskResult.m
@@ -11,7 +11,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface PINNSURLSessionDataTaskResult ()
-@property (nonatomic) NSData * _Nullable data;
+@property (nonatomic, copy) NSData * _Nullable data; //intentionally use copy as the network data might be NSMutableData under the hood
 @property (nonatomic) NSURLResponse * _Nullable response;
 @property (nonatomic) NSError * _Nullable error;
 @end


### PR DESCRIPTION
For NSData (the actual concrete type under the hood is OS_dispatch_data), i feel the copy here should be good because if the data is truly immutable, copy will just referenceCount++, and if its NSMutableData, then copy is just right.